### PR TITLE
README.md: Fix the broken URL to FileStream.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ All config files are placed in the config directory: `%appdata%\Notepad++\plugin
 
 FileStream.js
 -------------
-http://hp.vector.co.jp/authors/VA033015/fsjs.html
+~~http://hp.vector.co.jp/authors/VA033015/fsjs.html~~ (offline)
+
+http://ftp.vector.co.jp/46/91/2590/fsjs1081221.zip
 
 I randomly found this with Google.
 


### PR DESCRIPTION
Add a direct URL to the FileStream.js zip archive, as the website is no longer
online. The same content is available in the readme.html file included in the
zip archive.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>