### PR TITLE
Add: htm to supported file extensions

### DIFF
--- a/src/emmet/settings.json
+++ b/src/emmet/settings.json
@@ -1,4 +1,4 @@
 {
 	"enableTabExpensionByFileType": true,
-	"enableTabExpensionUnder": ["html", "css"]
+	"enableTabExpensionUnder": ["html", "htm", "css"]
 }


### PR DESCRIPTION
"htm" is the old DOS-compliant variant of the regular "html" file
extension used for HTML documents. There is no difference between
it and the regular "html" extension, thus Emmet should be enabled
by default in "htm" files too.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>